### PR TITLE
Minimum & LessOrEqual

### DIFF
--- a/omnn/math/Fraction.cpp
+++ b/omnn/math/Fraction.cpp
@@ -427,7 +427,7 @@ std::pair<bool,Valuable> Fraction::IsSummationSimplifiable(const Valuable& v) co
             auto& vfdn = vf.denominator();
             if (vfdn == constants::two)
                 ;
-            else if (vfdn.bit(constants::zero) != constants::one) {
+            else if (vfdn.bit() != constants::one) {
                 return Become(Exponentiation(*this, v));
             }
         }

--- a/omnn/math/test/logic.cpp
+++ b/omnn/math/test/logic.cpp
@@ -16,9 +16,7 @@ BOOST_AUTO_TEST_CASE(logic_or_tests
     BOOST_TEST(ok == set);
 }
 
-BOOST_AUTO_TEST_CASE(LessOrEqual_operator_test
-    , *disabled() // FIXME:
-) {
+BOOST_AUTO_TEST_CASE(LessOrEqual_operator_test) {
     DECL_VARS(X, Y);
     auto Minimum = X.Min(Y);
     auto LE = X.LessOrEqual(Y);


### PR DESCRIPTION
Enable LessOrEqual_operator_test test which checks Minimum & LessOrEqual declarative math operators in logic testing suite 