### PR TITLE
Use CMAKE_MSVC_RUNTIME_LIBRARY property for targets

### DIFF
--- a/cmake/bins.cmake
+++ b/cmake/bins.cmake
@@ -120,6 +120,7 @@ function(apply_target_commons this_target)
 		EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin
 		LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+		CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:DebugDLL>
 		)
 	target_compile_options(${this_target} PUBLIC
 		$<$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<CXX_COMPILER_ID:Clang>>>:-fcoroutines>

--- a/omnn/math/DuoValDescendant.h
+++ b/omnn/math/DuoValDescendant.h
@@ -182,8 +182,8 @@ namespace omnn::math {
                     f(*this);
                     return;
                 }
-                auto cache = Valuable::optimized;
-                // TODO: multival caching (inspect all optimized and optimization transisions) auto isCached = cach
+
+                // TODO: multival caching (inspect all optimized and optimization transisions)
                 
                 
                 Valuable::solutions_t vals, thisValues;

--- a/omnn/math/ValuableCollectionDescendantContract.h
+++ b/omnn/math/ValuableCollectionDescendantContract.h
@@ -234,7 +234,6 @@ namespace math {
         void Values(const std::function<bool(const Valuable&)>& fun) const override {
             auto& c = GetConstCont();
             auto count = c.size();
-            auto nTotal = count;
             auto sharedValuesProjection = std::vector<std::vector<Valuable>>();
             for (auto& m : c) {
                 if (m.IsMultival() == Valuable::YesNoMaybe::Yes) {

--- a/omnn/storage/LevelDbCache.h
+++ b/omnn/storage/LevelDbCache.h
@@ -3,7 +3,7 @@
 
 namespace leveldb {
 class DB;
-class Options;
+struct Options;
 }
 
 namespace omnn::rt::storage {


### PR DESCRIPTION
This removes runtime DLL dependencies from Release